### PR TITLE
added ancestor attribute to nodes to ensure that we can walk up the tree

### DIFF
--- a/newick.py
+++ b/newick.py
@@ -18,7 +18,7 @@ class Node(object):
     A Node has optional name and length (from parent) and a (possibly empty) list of
     descendants.
     """
-    def __init__(self, name=None, length=None, descendants=None):
+    def __init__(self, name=None, length=None, descendants=None, ancestor=None):
         for char in RESERVED_PUNCTUATION:
             if (name and char in name) or (length and char in length):
                 raise ValueError(
@@ -26,6 +26,9 @@ class Node(object):
         self.name = name
         self.length = length
         self.descendants = descendants or []
+        for descendant in self.descendants:
+            descendant.ancestor = self
+        self.ancestor = ancestor or None
 
     @property
     def newick(self):
@@ -147,7 +150,7 @@ def _parse_siblings(s):
             current.append(c)
 
 
-def parse_node(s):
+def parse_node(s, ancestor=None):
     s = s.strip()
     parts = s.split(')')
     if len(parts) == 1:
@@ -157,4 +160,5 @@ def parse_node(s):
             raise ValueError('unmatched braces %s' % parts[0][:100])
         descendants, label = list(_parse_siblings(')'.join(parts[:-1])[1:])), parts[-1]
     name, length = _parse_name_and_length(label)
-    return Node(name=name, length=length, descendants=descendants)
+    return Node(name=name, length=length, descendants=descendants,
+            ancestor=ancestor)

--- a/tests.py
+++ b/tests.py
@@ -34,6 +34,13 @@ class Tests(TestCase):
         self.assertEqual(
             [n.name for n in root.walk(mode='postorder')],
             ['A', 'B', 'C', 'D', 'E', 'F'])
+        self.assertEqual(root.ancestor, None)
+        self.assertEqual(root.descendants[0].ancestor, root)
+        root = loads('(((a,b),(c,d)),e);')[0]
+        self.assertEqual([n.ancestor.newick for n in root.walk()
+            if n.ancestor], ['(((a,b),(c,d)),e)', '((a,b),(c,d))', '(a,b)', 
+                '(a,b)', '((a,b),(c,d))', '(c,d)', '(c,d)',
+                '(((a,b),(c,d)),e)'])
 
     def test_loads(self):
         """parse examples from https://en.wikipedia.org/wiki/Newick_format"""


### PR DESCRIPTION
This is important, as far as I can tell, since it ensures that we can walk a tree up from a post-order traversal, as we often need, be it in parsimony, or in Felsenstein's pruning algorithm.

The solution for parent assignment in Node-initialization is not necessarily elegant, but I couldn't come up with a better one.
