### PR TITLE
Float branch lengths and utility functions

### DIFF
--- a/newick.py
+++ b/newick.py
@@ -10,6 +10,7 @@ import io
 
 RESERVED_PUNCTUATION = ':;,()'
 length_parser = lambda x: float(x or 0.0)
+length_formatter = str
 
 class Node(object):
     """
@@ -24,10 +25,17 @@ class Node(object):
                 raise ValueError(
                     'Node names or branch lengths must not contain "%s"' % char)
         self.name = name
-        self.s_length = length
-        self.length = length_parser(length)
+        self._length = length
         self.descendants = []
         self.ancestor = None
+
+    @property
+    def length(self):
+        return length_parser(self._length)
+
+    @length.setter
+    def length(self, l):
+        self._length = length_formatter(l)
 
     @classmethod
     def create(cls, name=None, length=None, descendants=None):
@@ -44,8 +52,8 @@ class Node(object):
     def newick(self):
         """The representation of the Node in Newick format."""
         label = self.name or ''
-        if self.s_length:
-            label += ':' + self.s_length
+        if self._length:
+            label += ':' + self._length
         descendants = ','.join([n.newick for n in self.descendants])
         if descendants:
             descendants = '(' + descendants + ')'

--- a/newick.py
+++ b/newick.py
@@ -9,7 +9,7 @@ import io
 
 
 RESERVED_PUNCTUATION = ':;,()'
-
+length_parser = lambda x: float(x or 0.0)
 
 class Node(object):
     """
@@ -24,7 +24,8 @@ class Node(object):
                 raise ValueError(
                     'Node names or branch lengths must not contain "%s"' % char)
         self.name = name
-        self.length = length
+        self.s_length = length
+        self.length = length_parser(length)
         self.descendants = []
         self.ancestor = None
 
@@ -43,8 +44,8 @@ class Node(object):
     def newick(self):
         """The representation of the Node in Newick format."""
         label = self.name or ''
-        if self.length:
-            label += ':' + self.length
+        if self.s_length:
+            label += ':' + self.s_length
         descendants = ','.join([n.newick for n in self.descendants])
         if descendants:
             descendants = '(' + descendants + ')'

--- a/newick.py
+++ b/newick.py
@@ -35,7 +35,10 @@ class Node(object):
 
     @length.setter
     def length(self, l):
-        self._length = length_formatter(l)
+        if l is None:
+            self._length = l
+        else:
+            self._length = length_formatter(l)
 
     @classmethod
     def create(cls, name=None, length=None, descendants=None):

--- a/tests.py
+++ b/tests.py
@@ -60,7 +60,7 @@ class Tests(TestCase):
 
         root = loads('(,,(,));')[0]
         self.assertIsNone(root.name)
-        self.assertIsNone(root.descendants[0].length)
+        self.assertEqual(root.descendants[0].length, 0.0)
         self.assertEqual(len(root.descendants), 3)
 
         root = loads('(A,B,(C,D));')[0]
@@ -73,12 +73,12 @@ class Tests(TestCase):
 
         root = loads('(:0.1,:0.2,(:0.3,:0.4):0.5);')[0]
         self.assertIsNone(root.name)
-        self.assertEqual(root.descendants[0].length, '0.1')
+        self.assertEqual(root.descendants[0].length, 0.1)
         self.assertEqual(len(root.descendants), 3)
 
         root = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
         self.assertEqual(root.name, 'A')
-        self.assertEqual(root.descendants[-1].length, '0.1')
+        self.assertEqual(root.descendants[-1].length, 0.1)
         self.assertEqual(len(root.descendants), 1)
 
     def test_dumps(self, *trees):


### PR DESCRIPTION
Here is my first attempt at implementing support for non-string branch lengths.  The module contains two functions, branch_parser and branch_formatter.  By default, these are:

`branch_parser = lambda x: float(x or 0)
branch_formatter = str`

but the user can override them by assigning their own functions to these names if necessary (I think these are quite conservative defaults - the parser should be able to handle the vast majority of trees in the wild.  If anybody knows of exceptions please let me know).  The formatter is necessary in case a parsed length is changed before the tree is dumped.  Faithful round-tripping continues to be supported.

Implementing this pluggable functionality with standalone functions feels a bit weird to me, but I didn't know how else to proceed - if they are methods of Node, subclassing Node to change them is no good, as parse_node is hard-coded to use the vanilla Node class.  Directly overriding class methods feels even weirder than doing so with standalone functions.  If there is some standard Pythonic way to do this, feel free to implement it.

Also included are a few utility functions, the ones of substance are pruning (removing a specified set of leaves, or removing all leaves except a specified set), removing redundant nodes (does this process have a well-known name?) and resolving polytomies.  All utility functions are < 10 LOC and take 2 parameters or less, so I don't feel like they compromise the minimalist spirit of the library, but I am very open to discussion on what does and does not get included.
