### PR TITLE
Removal functions

### DIFF
--- a/newick.py
+++ b/newick.py
@@ -98,6 +98,22 @@ class Node(object):
         for n in self.walk():
             n.name = None
 
+    def remove_internal_names(self):
+        """
+        Set the name of all non-leaf nodes in the subtree to None.
+        """
+        for n in self.walk():
+            if not n.is_leaf:
+                n.name = None
+
+    def remove_leaf_names(self):
+        """
+        Set the name of all leaf nodes in the subtree to None.
+        """
+        for n in self.walk():
+            if n.is_leaf:
+                n.name = None
+
     def remove_lengths(self):
         """
         Set the length of all nodes in the subtree to None.

--- a/newick.py
+++ b/newick.py
@@ -91,6 +91,20 @@ class Node(object):
             else:
                 stack.append(descendants[0])
 
+    def remove_names(self):
+        """
+        Set the name of all nodes in the subtree to None.
+        """
+        for n in self.walk():
+            n.name = None
+
+    def remove_lengths(self):
+        """
+        Set the length of all nodes in the subtree to None.
+        """
+        for n in self.walk():
+            n.length = None
+
 
 def loads(s):
     """

--- a/tests.py
+++ b/tests.py
@@ -112,6 +112,18 @@ class Tests(TestCase):
         nameless = dumps(tree)
         self.assertEqual(nameless, '((:0.2,(:0.3,:0.4):0.5):0.1);')
 
+    def test_internal_name_removal(self):
+        tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
+        tree.remove_internal_names()
+        nameless = dumps(tree)
+        self.assertEqual(nameless, '((B:0.2,(C:0.3,D:0.4):0.5):0.1);')
+
+    def test_leaf_name_removal(self):
+        tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
+        tree.remove_leaf_names()
+        nameless = dumps(tree)
+        self.assertEqual(nameless, '((:0.2,(:0.3,:0.4)E:0.5)F:0.1)A;')
+
     def test_length_removal(self):
         tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
         tree.remove_lengths()

--- a/tests.py
+++ b/tests.py
@@ -105,3 +105,22 @@ class Tests(TestCase):
             return c
 
         self.assertEqual(clone_node(tree1).newick, newick)
+
+    def test_name_removal(self):
+        tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
+        tree.remove_names()
+        nameless = dumps(tree)
+        self.assertEqual(nameless, '((:0.2,(:0.3,:0.4):0.5):0.1);')
+
+    def test_length_removal(self):
+        tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
+        tree.remove_lengths()
+        nameless = dumps(tree)
+        self.assertEqual(nameless, '((B,(C,D)E)F)A;')
+
+    def test_all_removal(self):
+        tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
+        tree.remove_names()
+        tree.remove_lengths()
+        topology_only = dumps(tree)
+        self.assertEqual(topology_only, '((,(,)));')


### PR DESCRIPTION
These commits would close #4, if people agree that #4 is an issue worth closing.

The first commit adds length removal and basic name removal (i.e. removal of all names).

The second commit refines basic name removal by adding versions which affect only internal nodes or leaf nodes.  Removing internal nodes only was motivated by the specific application of the BEASTling paper (Simon's reference Austronesian tree has named interior nodes  I do not need, and currently these are removed by slurping the tree as a string and using many calls of .replace("name","") - it would be nice to do this with a single, obvious line!).  Removing leaf names only feels like something people will rarely want to do, but it seemed wrong to have a function for one and not the other.
