### PR TITLE
Implemented functions for removing names and branch lengths, plus tests.

### DIFF
--- a/newick.py
+++ b/newick.py
@@ -181,6 +181,36 @@ class Node(object):
                 n.descendants.append(new)
         assert self.is_binary
 
+    def remove_names(self):
+        """
+        Set the name of all nodes in the subtree to None.
+        """
+        for n in self.walk():
+            n.name = None
+
+    def remove_internal_names(self):
+        """
+        Set the name of all non-leaf nodes in the subtree to None.
+        """
+        for n in self.walk():
+            if not n.is_leaf:
+                n.name = None
+
+    def remove_leaf_names(self):
+        """
+        Set the name of all leaf nodes in the subtree to None.
+        """
+        for n in self.walk():
+            if n.is_leaf:
+                n.name = None
+
+    def remove_lengths(self):
+        """
+        Set the length of all nodes in the subtree to None.
+        """
+        for n in self.walk():
+            n.length = None
+
 def loads(s):
     """
     Load a list of trees from a Newick formatted string.

--- a/tests.py
+++ b/tests.py
@@ -140,3 +140,34 @@ class Tests(TestCase):
         self.assertFalse(tree.is_binary)
         tree.resolve_polytomies()
         self.assertTrue(tree.is_binary)
+
+    def test_name_removal(self):
+        tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
+        tree.remove_names()
+        nameless = dumps(tree)
+        self.assertEqual(nameless, '((:0.2,(:0.3,:0.4):0.5):0.1);')
+
+    def test_internal_name_removal(self):
+        tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
+        tree.remove_internal_names()
+        nameless = dumps(tree)
+        self.assertEqual(nameless, '((B:0.2,(C:0.3,D:0.4):0.5):0.1);')
+
+    def test_leaf_name_removal(self):
+        tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
+        tree.remove_leaf_names()
+        nameless = dumps(tree)
+        self.assertEqual(nameless, '((:0.2,(:0.3,:0.4)E:0.5)F:0.1)A;')
+
+    def test_length_removal(self):
+        tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
+        tree.remove_lengths()
+        nameless = dumps(tree)
+        self.assertEqual(nameless, '((B,(C,D)E)F)A;')
+
+    def test_all_removal(self):
+        tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
+        tree.remove_names()
+        tree.remove_lengths()
+        topology_only = dumps(tree)
+        self.assertEqual(topology_only, '((,(,)));')


### PR DESCRIPTION
Functions to remove names and/or branch lengths from a tree.  Name removal can be done to internal or leaf nodes only.  These functions are handy for resolving incompatibilities between Newick output and input formats of different software.
