### PR TITLE
fixes #14

### DIFF
--- a/newick.py
+++ b/newick.py
@@ -194,7 +194,7 @@ class Node(object):
                     n.length += father.length
                 if grandfather:
                     for i,child in enumerate(grandfather.descendants):
-                        if id(child) == id(father):
+                        if child is father:
                             del grandfather.descendants[i]
                     grandfather.add_descendant(n)
                 else:

--- a/newick.py
+++ b/newick.py
@@ -24,7 +24,8 @@ class Node(object):
     A Node may be a tree, a subtree or a leaf.
 
     A Node has optional name and length (from parent) and a (possibly empty) list of
-    descendants.
+    descendants. It further has an ancestor, which is *None* if the node is the
+    root node of a tree.
     """
     def __init__(self, name=None, length=None, **kw):
         """

--- a/newick.py
+++ b/newick.py
@@ -185,13 +185,21 @@ class Node(object):
         :param preserve_lengths: If true, branch lengths of removed nodes are \
         added to those of their children.
         """
-        for n in self.walk(mode="preorder"):
-            while len(n.descendants) == 1:
-                only_child = n.descendants.pop()
-                for grandchild in only_child.descendants:
-                    n.add_descendant(grandchild)
-                    if preserve_lengths:
-                        grandchild.length += only_child.length
+        for n in self.walk(mode='postorder'):
+            if n.ancestor and len(n.ancestor.descendants) == 1:
+                grandfather = n.ancestor.ancestor
+                father = n.ancestor
+                if preserve_lengths: 
+                    n.length += father.length
+                if grandfather:
+                    for i,child in enumerate(grandfather.descendants):
+                        if id(child) == id(father):
+                            del grandfather.descendants[i]
+                    grandfather.add_descendant(n)
+                else:
+                    self.descendants = n.descendants
+                    if preserve_lengths: 
+                        self.length = n.length
 
     def resolve_polytomies(self):
         """

--- a/tests.py
+++ b/tests.py
@@ -141,6 +141,13 @@ class Tests(TestCase):
         tree.remove_redundant_nodes()
         self.assertFalse(any([len(n.descendants) == 1 for n in tree.walk()]))
 
+        tree2 = loads("((A:1,B:1):1,C:1)")[0]
+        tree2.prune_by_names(['A'])
+        assert tree2.newick == '((B:1):1,C:1)'
+        tree2.remove_redundant_nodes()
+        assert tree2.newick == '(C:1,B:2.0)'
+
+
     def test_polytomy_resolution(self):
 
         tree = loads('(A,B,(C,D,(E,F)))')[0]


### PR DESCRIPTION
This is a proposal to fix #14. Instead of pre-order, this function goes post-order, whenever a node has no sibling, it is moved one on top, to be identical with its direct ancestor. The special case of structures like 

``` text
((a,b));
```

where the first node of the tree has only one child is handled by re-defining the ancestors of the object itself. Unfortunately, this case could not be generalised within the normal procedure, and as a result, the method gets longer than the previous one.

Note that the previous one failed, since the tests did not cover the normal case of tree-internal redundant nodes, as the tests only checked for the root-node being redundant. This is now explicitly handled in the tests as well, where I added the test-case in #14.
