### PR TITLE
format all lengths according to the length formatter consistently

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -143,9 +143,9 @@ class Tests(TestCase):
 
         tree2 = loads("((A:1,B:1):1,C:1)")[0]
         tree2.prune_by_names(['A'])
-        assert tree2.newick == '((B:1):1,C:1)'
+        assert tree2.newick == '((B:1.0):1.0,C:1.0)'
         tree2.remove_redundant_nodes()
-        assert tree2.newick == '(C:1,B:2.0)'
+        assert tree2.newick == '(C:1.0,B:2.0)'
 
     def test_polytomy_resolution(self):
         tree = loads('(A,B,(C,D,(E,F)))')[0]


### PR DESCRIPTION
This fixes #17, but please make all sure that this is the wanted behaviour (especially @lmaurits, who is currently using newick most in beastling, and who should make sure this doesn't break things).

The new output of tree.newick, after parsing a tree with lengths and the standard length_formatter, is:

``` python
>>> tree = newick.loads('((a:1,b:2):3,(c:1,d:1):2);')[0]
>>> print(tree.newick)
((a:1.0,b:2.0):3.0,(c:1.0,d:1.0):2.0)
```

For me, this is way more consistent than the earlier version, where the original string was retained, and it is also certainly not good that **kw was not further passed down to the siblings, but retained in the parse_node function upon first call, but I'd be open to arguments against this behaviour, since it changes the original newick-string that was parsed.
