### PR TITLE
Make newick deal with stacked singletons

### DIFF
--- a/newick.py
+++ b/newick.py
@@ -186,8 +186,8 @@ class Node(object):
         :param preserve_lengths: If true, branch lengths of removed nodes are \
         added to those of their children.
         """
-        for n in self.walk(mode='postorder'):
-            if n.ancestor and len(n.ancestor.descendants) == 1:
+        for n in self.walk(mode='preorder'):
+            while n.ancestor and len(n.ancestor.descendants) == 1:
                 grandfather = n.ancestor.ancestor
                 father = n.ancestor
                 if preserve_lengths: 
@@ -214,7 +214,7 @@ class Node(object):
                 while len(n.descendants) > 1:
                     new.add_descendant(n.descendants.pop())
                 n.descendants.append(new)
-        assert self.is_binary
+        assert self.is_binary, "{:s} should be binary".format(self.newick)
 
     def remove_names(self):
         """

--- a/tests.py
+++ b/tests.py
@@ -141,11 +141,17 @@ class Tests(TestCase):
         tree.remove_redundant_nodes()
         self.assertFalse(any([len(n.descendants) == 1 for n in tree.walk()]))
 
+    def test_prune_and_node_removal(self):
         tree2 = loads("((A:1,B:1):1,C:1)")[0]
         tree2.prune_by_names(['A'])
-        assert tree2.newick == '((B:1):1,C:1)'
+        self.assertEqual(tree2.newick, '((B:1):1,C:1)')
         tree2.remove_redundant_nodes()
-        assert tree2.newick == '(C:1,B:2.0)'
+        self.assertEqual(tree2.newick, '(C:1,B:2.0)')
+
+    def test_stacked_redundant_node_removal(self):
+        tree = loads("((((A,B))),C)")[0]
+        tree.remove_redundant_nodes()
+        self.assertEqual(tree.newick, "(C,(A,B):0.0)")
 
     def test_polytomy_resolution(self):
         tree = loads('(A,B,(C,D,(E,F)))')[0]


### PR DESCRIPTION
This patch includes a test for a tree with stacked singletons, and the second removes_redundant_nodes test has been split out.
Fixes #19
