### PR TITLE
Naive support for comments in newick string

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -189,3 +189,10 @@ class Tests(TestCase):
         self.assertEqual(len(list(tree.walk())), 11)
         tree.remove_redundant_nodes()
         self.assertEqual(len(list(tree.walk())), 9)
+
+    def test_comments(self):
+        t = '[&R] (A,B)C [% ] [% ] [%  setBetweenBits = selected ];'
+        with self.assertRaises(ValueError):
+            loads(t)
+        tree = loads(t, strip_comments=True)[0]
+        self.assertEqual(len(list(tree.walk())), 3)


### PR DESCRIPTION
This PR proposes a - rather naive - implementation of support
for comments in newick strings:
- Comments are everything between `[` and the first following `]`.
- `[` and `]` can still be used as node labels in trees which have
  been created by parsing newick with comments stripped.
- Comments are simply stripped upon readin, and cannot be recovered
  when writing; thus, round-tripping won't work with comments.

Closes #9
