### PR TITLE
Prune node 

### DIFF
--- a/newick.py
+++ b/newick.py
@@ -188,9 +188,6 @@ class Node(object):
         :param inverse: Specifies whether to remove nodes in the list or not\
                 in the list.
         """
-        if not all([n.is_leaf for n in leaves]):
-            raise ValueError("prune only accepts leaf nodes")
-
         self.visit(
             lambda n: n.ancestor.descendants.remove(n),
             # We won't prune the root node, even if it is a leave and requested to

--- a/tests.py
+++ b/tests.py
@@ -225,4 +225,11 @@ class Tests(TestCase):
         # rename
         tree.get_node('E').name = 'G'
         self.assertEqual(tree.newick, '(A,B,(C,D)G)F')
-        
+    
+    def test_prune_node(self):
+        tree = '(A,(B,(C,D)E)F)G;'
+        t1 = loads(tree)[0]
+        t1.prune_by_names(["C", "D"])
+        t2 = loads(tree)[0]
+        t2.prune_by_names(["E"])
+        self.assertEqual(t1.newick, t2.newick)

--- a/tests.py
+++ b/tests.py
@@ -134,10 +134,6 @@ class Tests(TestCase):
         tree.prune(tree.get_leaves())
         self.assertEqual(tree.newick, 'A')
 
-    def test_bad_prune(self):
-        tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
-        self.assertRaises(ValueError, tree.prune_by_names, ['E'])
-
     def test_redundant_node_removal(self):
         tree = loads('((B:0.2,(C:0.3,D:0.4)E:0.5)F:0.1)A;')[0]
         self.assertEqual(len(tree.descendants), 1)
@@ -229,7 +225,7 @@ class Tests(TestCase):
     def test_prune_node(self):
         tree = '(A,(B,(C,D)E)F)G;'
         t1 = loads(tree)[0]
-        t1.prune_by_names(["C", "D"])
+        t1.prune_by_names(["C", "D", "E"])
         t2 = loads(tree)[0]
         t2.prune_by_names(["E"])
         self.assertEqual(t1.newick, t2.newick)


### PR DESCRIPTION
Fix for #12 

This PR makes `prune` remove nodes too. I can't think of any reason to not allow deleting of nodes as it's a common manipulation so people will want to do it. e.g.

```python
tree = "(A,(B,(C,D)E)F)G;"

# I want to remove node E containing C and D. Naively, you might expect removing C & D to work:
t = loads(tree)[0]
t.prune_by_names(["C", "D"])
print(t.newick)
```

>>> (A,(B,E)F)G   

Note that `E` is still there (this is I think linked to issue #27?). To remove E as well, I need to run `t.prune_by_names(["C", "D", "E"])`

Compare to the behavior in this PR:

```
t = loads(tree)[0]
t.prune_by_names(["E"])
print(t.newick)
```

>>> (A,(B)F)G
