### PR TITLE
Fix ascii art breaking on singleton nodes

### DIFF
--- a/newick.py
+++ b/newick.py
@@ -106,7 +106,9 @@ class Node(object):
             mids = []
             result = []
             for i, c in enumerate(self.descendants):
-                if i == 0:
+                if len(self.descendants) == 1:
+                    char2 = '\u2500'
+                elif i == 0:
                     char2 = '\u250c'
                 elif i == len(self.descendants) - 1:
                     char2 = '\u2514'
@@ -123,7 +125,7 @@ class Node(object):
                        [pad + '\u2502'] * (hi - lo - 1) + \
                        [pad] * (end - hi)
             mid = (lo + hi) // 2
-            prefixes[mid] = char1 + '\u2500' * (maxlen - 2) + prefixes[mid][-1]
+            prefixes[mid] = char1 + '\u2500' * (len(prefixes[mid]) - 2) + prefixes[mid][-1]
             result = [p + l for p, l in zip(prefixes, result)]
             if show_internal:
                 stem = result[mid]

--- a/tests.py
+++ b/tests.py
@@ -166,6 +166,13 @@ class Tests(unittest.TestCase):
 ----+-B
     \-C""")
 
+    def test_Node_ascii_art_singleton(self):
+        self.assertEqual(
+            loads('((A,B)C)Ex;')[0].ascii_art(strict=True), """\
+          /-A
+--Ex --C--|
+          \-B""")
+
     def test_loads(self):
         """parse examples from https://en.wikipedia.org/wiki/Newick_format"""
 


### PR DESCRIPTION
With this fix there is a space before each singleton node (which looks fine to me, but maybe you prefer to have an unbroken line).