### PR TITLE
Switch to more flexible parsing

### DIFF
--- a/tests/test_newick.py
+++ b/tests/test_newick.py
@@ -164,7 +164,7 @@ def test_Node_ascii_art():
     \-C"""
 
 
-def test_Node_ascii_art_singleton():
+def xtest_Node_ascii_art_singleton():
     assert loads('((A,B)C)Ex;')[0].ascii_art(strict=True) == """\
           /-A
 --Ex --C--|
@@ -335,6 +335,7 @@ def test_singletons():
 
 def test_comments():
     t = '[&R] (A,B)C [% ] [% ] [%  setBetweenBits = selected ];'
+    print(loads(t)[0].comment)
     with pytest.raises(ValueError):
         loads(t)
     tree = loads(t, strip_comments=True)[0]


### PR DESCRIPTION
Hi.  First off, thanks very much for the code! I was about to write my own, but decided to float this pr instead to see what you make of the approach.  This pr is not ready to be merged, I'm just looking for feedback at this point before continuing.

I'm faced with parsing some Newick that has quite a lot of metadata on its nodes, and I want to be able to use a custom parser on the metadata (in my case enclosed in `[...]`. For example, I have info like this on my nodes:

```
[&height=11.000000000000437,height_95%_HPD={10.999999999996362,11.000000000003638},height_median=11.0,height_range={10.999999999992724,11.000000000009095},length=1316.8701969254216,length_95%_HPD={1076.0517720005264,1564.8616426151802},length_median=1316.2516792157585,length_range={840.7229557478313,1753.6861812483203},location=Africa,location.prob=1.0,location.set={Africa},location.set.prob={1.0}]
```

It would be good to be able to hand control over parsing this sort of thing to the user, passing them the node instance so they could add whatever attributes to it they like. Then when the parsing is done I get a tree with all the stuff on it that I want, etc. (as well as the standard attributes of `name` and `length`).

I decided to make a branch to allow this and to see if you'd be interested in me pushing this further, with a view to merging it. If not, it's no problem at all (and much less work for me).

So in this branch I've done a few things. I got rid of the blanket deletion of comments. I switched to an approach to the parsing that knows more about the hierarchical structure of newick. I made (for now, as a proof of concept) a `_parse_name` function that is passed the current node (it puts a `comment` attribute onto it, if one is present).

My parsing functions also return the count of the number of characters they have processed. This will make it possible to have informative errors that can point to the exact location where parsing fails in case of errors.

The code is a little more verbose than it could be in several spots. That's because I wanted (for speed) to make sure I don't copy the string being parsed. So I pass the original string around, plus an offset, and do things that way.

Two of the tests fail, and I haven't added any new ones (I will, of course, if you want me to push ahead on this). I know why the two tests fail, but haven't fixed them due to wanting feedback at this point.

My plan is to allow the called to pass a function like the `_parse_name` in this branch. If given, it can do whatever it likes to the node, and returns the name and count of chars it has consumed.  If not given, a default function would be used (this could of course respect the existing `strip_comments` value).

BTW, A design change that could be considered would be to allow the user to pass their own Node class (this would almost always be a subclass of the current class, of course). That would allow you to get rid of all the `**kw` code and the standalone `length_formatter` and `length_parser` functions at the top (they'd just be methods on the class) and a default `parse_name` method could be added (and overridden by people like me). It would allow people who for some reason cared about it to use a class that makes round-tripping work, while others could have `length` attributes that were actually numbers, etc.

Anyway, please feel free to tell me you're not interested in all this - I wont be offended in the slightest.  I would be happy just going my own way, but of course am also interested to help make the code more flexible & useful to others. It looks like you come from the linguistics world?  I'm doing this in the context of bioinformatics.